### PR TITLE
Make the .gwt.xml file inherit RegExodus

### DIFF
--- a/stripe/src/com/ray3k/stripe.gwt.xml
+++ b/stripe/src/com/ray3k/stripe.gwt.xml
@@ -4,6 +4,7 @@
 <module>
     <source path=""/>
     <inherits name="com.badlogic.gdx.backends.gdx_backends_gwt" />
+    <inherits name="regexodus"/>
     <extend-configuration-property name="gdx.reflect.include" value="com.ray3k.stripe"/>
     <extend-configuration-property name="gdx.reflect.include" value="com.badlogic.gdx.graphics.g2d.freetype.FreeTypeFontGenerator"/>
     <extend-configuration-property name="gdx.reflect.include" value="com.badlogic.gdx.graphics.g2d.PixmapPacker"/>


### PR DESCRIPTION
I haven't tested this at all, but it should at least help if Stripe depends on RegExodus. It's one line and should only affect GWT.