### PR TITLE
Try to fix javadoc build.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,19 @@ allprojects {
         maven { url "https://oss.sonatype.org/content/repositories/releases/" }
         maven { url 'https://jitpack.io' }
     }
+
+// Disable JDK 8's doclint
+// http://blog.joda.org/2014/02/turning-off-doclint-in-jdk-8-javadoc.html
+    if (JavaVersion.current().isJava8Compatible()) {
+        allprojects {
+            tasks.withType(Javadoc) {
+                // The -quiet is because of some sort of weird JDK JavaCompiler bug:
+                // https://discuss.gradle.org/t/passing-arguments-to-compiler-and-javadoc/1661
+                options.addStringOption('Xdoclint:none,-missing', '-quiet')
+            }
+        }
+    }
+
 }
 
 project(":stripe") {
@@ -44,7 +57,6 @@ project(":stripe") {
     dependencies {
         api "com.badlogicgames.gdx:gdx:$gdxVersion"
         api 'com.github.tommyettinger:regexodus:0.1.15'
-        api 'com.github.tommyettinger:regexodus:0.1.15:sources'
     }
 
     task sourcesJar(type: Jar, dependsOn: classes) {
@@ -71,7 +83,6 @@ project(":freetype") {
         api "com.badlogicgames.gdx:gdx:$gdxVersion"
         api "com.badlogicgames.gdx:gdx-freetype:$gdxVersion"
         api 'com.github.tommyettinger:regexodus:0.1.15'
-        api 'com.github.tommyettinger:regexodus:0.1.15:sources'
     }
 
     task sourcesJar(type: Jar, dependsOn: classes) {

--- a/colorpicker/build.gradle
+++ b/colorpicker/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: "java"
 
 sourceCompatibility = 1.6
-[compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
+[compileJava, compileTestJava, javadoc]*.options*.encoding = 'UTF-8'
 
 sourceSets.main.java.srcDirs = [ "src/" ]
 sourceSets.main.resources.srcDirs = ["src"]

--- a/freetype/build.gradle
+++ b/freetype/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: "java"
 
 sourceCompatibility = 1.6
-[compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
+[compileJava, compileTestJava, javadoc]*.options*.encoding = 'UTF-8'
 
 sourceSets.main.java.srcDirs = [ "src/" ]
 sourceSets.main.resources.srcDirs = ["src"]

--- a/stripe/build.gradle
+++ b/stripe/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: "java"
 
 sourceCompatibility = 1.6
-[compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
+[compileJava, compileTestJava, javadoc]*.options*.encoding = 'UTF-8'
 
 sourceSets.main.java.srcDirs = [ "src/" ]
 sourceSets.main.resources.srcDirs = ["src"]


### PR DESCRIPTION
This disables Java 8's strict linting, ensures javadoc uses UTF-8 like some other tasks already have ensured for themselves, and removes the :sources dependencies on RegExodus (they're only used on GWT, and might cause problems elsewhere, though they really shouldn't). The javadoc build is only broken for stripe, and only on JitPack, so this might be totally unrelated. These are still things I try to do in all my projects.